### PR TITLE
archive list layout default value from int to str

### DIFF
--- a/layouts/archive/list.html
+++ b/layouts/archive/list.html
@@ -10,7 +10,7 @@
 </span>
 <main class="main archive">
   <div>
-    {{ range (and (where .Site.RegularPages "Type" "!=" "about") (where .Site.RegularPages "Type" "!=" "archive")).GroupByDate (.Site.Params.archiveGroupByDate | default 2006) }}
+    {{ range (and (where .Site.RegularPages "Type" "!=" "about") (where .Site.RegularPages "Type" "!=" "archive")).GroupByDate (.Site.Params.archiveGroupByDate | default "2006") }}
     <span class="archive__key">{{ .Key }}</span>
     <ul class="archive__ul">
       {{ range .Pages }}


### PR DESCRIPTION
When building the site, without config params `archiveGroupByDate` set, hugo throws an error as the default type is not correct. 

```
Rebuild failed:

Failed to render pages: render of "section" failed: "/hugo/themes/zzo/layouts/archive/list.html:13:170": execute of template failed: template: archive/list.html:13:170: executing "main" at <2006>: wrong type for value; expected string; got int
```