### PR TITLE
Small design improvements

### DIFF
--- a/assets/sass/pages/_talk.scss
+++ b/assets/sass/pages/_talk.scss
@@ -17,7 +17,6 @@
     border-radius: 0.25rem;
     min-width: 100px;
     max-width: 100px;
-    margin-top: 0.25rem;
     font-size: 16px;
     height: 26px;
     line-height: 26px;
@@ -65,7 +64,7 @@
           position: absolute;
           left: 3rem;                
           width: 0.25rem;
-          height: 20px;
+          height: 30px;
           
           @include themify($themes) {
             background-color: themed('archive-hover-line-color');

--- a/layouts/partials/body/infos.html
+++ b/layouts/partials/body/infos.html
@@ -1,6 +1,6 @@
 {{ $params := .Params }}
 <div class="single__infos">
-  <span class="single__info" title="{{ i18n "tooltip-written" }}">📅&nbsp;{{ .Date.Format (i18n "single-dateformat") }} </span> {{ if .GitInfo }} &nbsp;&nbsp; <span class="single__info" title="{{ i18n "tooltip-modified" }}"> 📝{{ .Lastmod.Format (i18n "single-dateformat") }} </span> {{ end }} &middot; <span class="single__info" title="{{ i18n "tooltip-reading-time" }}"> ☕{{ .ReadingTime }} {{ i18n "reading-time" }} </span>{{ with .Params.Author }}&middot; <span class="single__info" title="{{ i18n "single-writtenBy" }}">{{if $params.AuthorEmoji }}{{ $params.AuthorEmoji }}{{ else }}✍️{{ end }}&nbsp;{{ . }}</span>{{ end }}
+  <span class="single__info" title="{{ i18n "tooltip-written" }}">📅&nbsp;{{ .Date.Format (i18n "single-dateformat") }} </span> {{ if .GitInfo }} &nbsp;&nbsp; <span class="single__info" title="{{ i18n "tooltip-modified" }}"> 📝{{ .Lastmod.Format (i18n "single-dateformat") }} </span> {{ end }} &middot; <span class="single__info" title="{{ i18n "tooltip-reading-time" }}"> ☕ {{ .ReadingTime }} {{ i18n "reading-time" }} </span>{{ with .Params.Author }}&middot; <span class="single__info" title="{{ i18n "single-writtenBy" }}">{{if $params.AuthorEmoji }}{{ $params.AuthorEmoji }}{{ else }}✍️{{ end }}&nbsp;{{ . }}</span>{{ end }}
   <span class="single__info">
     {{ if (and .Site.Params.enableBusuanzi .Site.Params.busuanziPagePV) }} &middot; 👀<span id="busuanzi_value_page_pv">...</span> {{ i18n "counter-page-pv" }}{{ end }}
   </span>

--- a/layouts/partials/summary/card.html
+++ b/layouts/partials/summary/card.html
@@ -1,7 +1,7 @@
 <article class="summary-card">
   <header>
     <h5 class="title h5"><a href='{{ .Permalink }}'> {{ .Title }}</a> </h5>
-    <h6 class="subtitle caption"><span title="{{ i18n "tooltip-written" }}">📅{{ .Date.Format (i18n "summary-dateformat") }} </span> {{ if .GitInfo }} <span title="{{ i18n "tooltip-modified" }}"> &middot; 📝 {{ .Lastmod.Format (i18n "summary-dateformat") }} </span> {{ end }} <span title="{{ i18n "tooltip-reading-time" }}"> &middot; ☕{{ .ReadingTime }} {{ i18n "reading-time" }}</span>{{ with .Params.Author }}&middot; <span title="{{ i18n "single-writtenBy" }}">{{if .Params.AuthorEmoji }}{{ .Params.AuthorEmoji }}{{ else }}✍️{{ end }}&nbsp;{{ . }}</span>{{ end }}</h6>
+    <h6 class="subtitle caption"><span title="{{ i18n "tooltip-written" }}">📅{{ .Date.Format (i18n "summary-dateformat") }} </span> {{ if .GitInfo }} <span title="{{ i18n "tooltip-modified" }}"> &middot; 📝 {{ .Lastmod.Format (i18n "summary-dateformat") }} </span> {{ end }} <span title="{{ i18n "tooltip-reading-time" }}"> &middot; ☕ {{ .ReadingTime }} {{ i18n "reading-time" }}</span>{{ with .Params.Author }}&middot; <span title="{{ i18n "single-writtenBy" }}">{{if .Params.AuthorEmoji }}{{ .Params.AuthorEmoji }}{{ else }}✍️{{ end }}&nbsp;{{ . }}</span>{{ end }}</h6>
   </header>
   {{ $params := .Params }}
   <div class="summary-card__content">

--- a/layouts/partials/summary/classic.html
+++ b/layouts/partials/summary/classic.html
@@ -11,7 +11,7 @@
     <div class="summary-classic__content">
       <header>
         <h5 class="title h5"><a href='{{ .Permalink }}'> {{ .Title }}</a> </h5>
-        <h6 class="subtitle caption"><span title="{{ i18n "tooltip-written" }}">📅 {{ .Date.Format (i18n "summary-dateformat") }} </span> {{ if .GitInfo }} <span title="{{ i18n "tooltip-modified" }}"> &middot; 📝 {{ .Lastmod.Format (i18n "summary-dateformat") }} </span> {{ end }} <span title="{{ i18n "tooltip-reading-time" }}"> &middot; ☕{{ .ReadingTime }} {{ i18n "reading-time" }} </span>{{ with .Params.Author }}&middot; <span title="{{ i18n "single-writtenBy" }}">{{if $params.AuthorEmoji }}{{ $params.AuthorEmoji }}{{ else }}✍️{{ end }}&nbsp;{{ . }}</span>{{ end }}</h6>
+        <h6 class="subtitle caption"><span title="{{ i18n "tooltip-written" }}">📅 {{ .Date.Format (i18n "summary-dateformat") }} </span> {{ if .GitInfo }} <span title="{{ i18n "tooltip-modified" }}"> &middot; 📝 {{ .Lastmod.Format (i18n "summary-dateformat") }} </span> {{ end }} <span title="{{ i18n "tooltip-reading-time" }}"> &middot; ☕ {{ .ReadingTime }} {{ i18n "reading-time" }} </span>{{ with .Params.Author }}&middot; <span title="{{ i18n "single-writtenBy" }}">{{if $params.AuthorEmoji }}{{ $params.AuthorEmoji }}{{ else }}✍️{{ end }}&nbsp;{{ . }}</span>{{ end }}</h6>
       </header>
       <div>
         <div class="summary-classic__text p2">

--- a/layouts/partials/summary/compact.html
+++ b/layouts/partials/summary/compact.html
@@ -4,7 +4,7 @@
     <div class="summary-compact__meta">
       <header>
         <h5 class="title h6"><a href='{{ .Permalink }}'> {{ .Title }}</a> </h5>
-        <h6 class="subtitle caption"><span title="{{ i18n "tooltip-written" }}">📅 {{ .Date.Format (i18n "summary-dateformat") }} </span> {{ if .GitInfo }} <span title="{{ i18n "tooltip-modified" }}"> &middot; 📝 {{ .Lastmod.Format (i18n "summary-dateformat") }} </span> {{ end }} <span title="{{ i18n "tooltip-reading-time" }}"> &middot; ☕{{ .ReadingTime }} {{ i18n "reading-time" }}</span>{{ with .Params.Author }}&middot; <span title="{{ i18n "single-writtenBy" }}">{{if $params.AuthorEmoji }}{{ $params.AuthorEmoji }}{{ else }}✍️{{ end }}&nbsp;{{ . }}</span>{{ end }}</h6>
+        <h6 class="subtitle caption"><span title="{{ i18n "tooltip-written" }}">📅 {{ .Date.Format (i18n "summary-dateformat") }} </span> {{ if .GitInfo }} <span title="{{ i18n "tooltip-modified" }}"> &middot; 📝 {{ .Lastmod.Format (i18n "summary-dateformat") }} </span> {{ end }} <span title="{{ i18n "tooltip-reading-time" }}"> &middot; ☕ {{ .ReadingTime }} {{ i18n "reading-time" }}</span>{{ with .Params.Author }}&middot; <span title="{{ i18n "single-writtenBy" }}">{{if $params.AuthorEmoji }}{{ $params.AuthorEmoji }}{{ else }}✍️{{ end }}&nbsp;{{ . }}</span>{{ end }}</h6>
       </header>
     </div>
   </div>


### PR DESCRIPTION
The title, the highlight bar (was smaller, so looked like it was off) and the date are not aligned on the same baseline:
![Screenshot from 2020-01-06 23-54-06](https://user-images.githubusercontent.com/2096087/71855795-4fee9780-30e2-11ea-994e-551e728967d4.png)

This PR fixes it.

Also added a space after the coffee emoji.
