### PR TITLE
remove duplicated socialOptions:zhihu in README

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -347,7 +347,6 @@ commento = false
   gitlab = ""
   mastodon = ""
   jianshu = ""
-  zhihu = ""
 
 [donationOptions] 
   enable = false # if set, the donation button will show up on the single page.

--- a/README.md
+++ b/README.md
@@ -341,7 +341,6 @@ commento = false
   gitlab = ""
   mastodon = ""
   jianshu = ""
-  zhihu = ""
 
 [donationOptions] 
   enable = false # if set, the donation button will show up on the single page.


### PR DESCRIPTION
`params.toml` in README have duplicated `socialOptions` `zhihu = ""` that will cause error when generating HTML.