### PR TITLE
Remove bogus span tag in talks list

### DIFF
--- a/layouts/talks/list.html
+++ b/layouts/talks/list.html
@@ -9,7 +9,6 @@
     {{ .Content }}
   </div>
 </header>
-</span>
 <main class="main archive">
   <div class="archive__container">
     {{ $pages := (where .Site.RegularPages "Section" "talks") }}


### PR DESCRIPTION
It seems to be a leftover.
