### PR TITLE
Wrong number of arguments

### DIFF
--- a/layouts/partials/body/whoami.html
+++ b/layouts/partials/body/whoami.html
@@ -5,7 +5,7 @@
   <div class="whoami__image-wrapper">
     {{ $src := "" }}
     {{ if site.Params.useGravatar }}
-      {{ $src = printf "https://s.gravatar.com/avatar/%s?s=200" (md5 $.Param "email") }}
+      {{ $src = printf "https://s.gravatar.com/avatar/%s?s=200" (md5 ($.Param "email")) }}
       <img src="{{ $src }}" alt="{{ if $.Param "myname" }}{{ $.Param "myname" }}{{ else }}Avatar{{ end }}" class="whoami__image"/>
     {{ else }}
       {{ if $.Param "authorImageUrl" }}

--- a/layouts/partials/sidebar/site-bio.html
+++ b/layouts/partials/sidebar/site-bio.html
@@ -4,7 +4,7 @@
   <div class="bio__photo-wrapper">    
     {{ $src := "" }}
     {{ if site.Params.useGravatar }}    
-      {{ $src = printf "https://s.gravatar.com/avatar/%s?s=200" (md5 $.Param "email") }}
+      {{ $src = printf "https://s.gravatar.com/avatar/%s?s=200" (md5 ($.Param "email")) }}
       <img src="{{ $src }}" alt="{{ if $.Param "myname" }}{{ $.Param "myname" }}{{ else }}Avatar{{ end }}" class="bio__photo"/>
     {{ else }}
       {{ if $.Param "bioImageUrl" }}


### PR DESCRIPTION
Some changes from 48b4144bb1fb8bcf3219537464622f23bdb3c8d5 caused the bug.
![image](https://user-images.githubusercontent.com/33273948/73517183-5516dc00-442d-11ea-8a8b-e4be39481463.png)

I figured that `md5` takes both the `$.Param` and `"email"` as arguments, so I added some parentheses and it works.