### PR TITLE
enableBioImage to manage bio image in home page sidebar

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -270,7 +270,8 @@ organization = "Hugo"
 link = "https://github.com/zzossig/hugo-theme-zzo"
 
 # sidebar
-enableBio = true # home page sidebar
+enableBio = true # in home page sidebar
+enableBioImage = true # in home page sidebar
 enableSidebar = true # Set to false to create the full width of the content.
 enableSidebarTags = true # if you want to use tags.
 enableSidebarSeries = true

--- a/README.md
+++ b/README.md
@@ -278,7 +278,8 @@ organization = "Hugo"
 link = "https://github.com/zzossig/hugo-theme-zzo"
 
 # sidebar
-enableBio = true # home page sidebar
+enableBio = true # in home page sidebar
+enableBioImage = true # in home page sidebar
 enableSidebar = true # Set to false to create the full width of the content.
 enableSidebarTags = true # if you want to use tags.
 enableSidebarSeries = true

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -41,6 +41,7 @@ link = "https://zzossig.io/ko"
 
 # sidebar
 enableBio = true
+enableBioImage = true
 enableSidebar = true
 enableSidebarTags = true
 enableSidebarSeries = true

--- a/layouts/partials/sidebar/site-bio.html
+++ b/layouts/partials/sidebar/site-bio.html
@@ -1,5 +1,6 @@
 {{ if $.Param "enableBio" }}
 <section class="bio" data-dir="{{ $.Param "languagedir" | default "ltr" }}">
+  {{ if ($.Param "enableBioImage" | default true) }}
   <hr class="hr-slash bio-hr"/>
   <div class="bio__photo-wrapper">
     {{ $src := "" }}
@@ -20,6 +21,7 @@
       {{ end }}     
     {{ end }}
   </div>
+  {{ end }}
   <hr class="hr-slash bio-hr"/>
   <div class="bio__name">
     {{ $.Param "myname" }}


### PR DESCRIPTION
Without that there was no easy way to just disable showing the bio image in the home page sidebar.

Image is still enabled by default.