### PR TITLE
Ability to display well formatter longer description in talks page

### DIFF
--- a/layouts/talks/list.html
+++ b/layouts/talks/list.html
@@ -5,11 +5,21 @@
   <h3 class="h3 terms__title">
     {{ .Title }}
   </h3>
+  {{ if not .Params.subtitle }}
   <div>
     {{ .Content }}
   </div>
+  {{ end }}
 </header>
 <main class="main archive">
+  {{ if .Params.subtitle }}
+  <div class="archive__content">
+    {{ .Content }}
+  </div>
+  <h4 class="archive__subtitle">
+    {{ .Params.subtitle }}
+  </h4>
+  {{ end }}
   <div class="archive__container">
     {{ $pages := (where .Site.RegularPages "Section" "talks") }}
     {{ $paginator := .Paginate ($pages.GroupByPublishDate ($.Param "talksGroupByDate" | default "2006")) ($.Param "talksPaginate") }}


### PR DESCRIPTION
By default content is used as a subtitle - displayed right under Title
without extra formatting (to keep backward compatibility). However,
it doesn't look good to longer (multiline) content (margins, etc.).
For that cases there is an option to define the Subtitle parameter in `_index.md`
to render is as a subtitle and then `.Content` is rendered within the main tag
with better formatting.

I modeled it the way it preserves the original formatting if there is no `Subtitle` defined in the md file.

My use case.

Before (no margings - everything in the header):
![image](https://user-images.githubusercontent.com/148013/74437469-7681ba00-4e68-11ea-8f91-537963deb42b.png)

After (better margins, place for a subtitle - with `subtitle: "List of my public speeches"` added in `_index.md`):
![image](https://user-images.githubusercontent.com/148013/74439079-cf9f1d00-4e6b-11ea-9fb1-91e1aea7c816.png)

**Important**. In my custom.css I did the following changes to improve the output:
```
div.archive__content {
    margin-bottom: 2rem;
}
h4.archive__subtitle {
    text-align: center
}
```
However, I don't know scss, so if you like that change please apply it also to `.scss` files. I'm newbie to CSS, so feel free to improve styling.