### PR TITLE
Ability to disable link do talk page or provide external one

### DIFF
--- a/layouts/talks/list.html
+++ b/layouts/talks/list.html
@@ -22,7 +22,12 @@
         <span class="talk__date" data-dir="{{ $.Param "languagedir" | default "ltr" }}">
           {{ .PublishDate.Format (i18n "talks-dateformat") }}
         </span>
-        <a href="{{ .Permalink }}" class="talk__title" data-title-wrap="{{ $titleWrap | default "wrap"}}" data-dir="{{ $.Param "languagedir" | default "ltr" }}">{{ .Title }}</a>
+        {{ if .Params.disableLink }}
+        <div class="talk__title" data-title-wrap="{{ $titleWrap | default "wrap"}}" data-dir="{{ $.Param "languagedir" | default "ltr" }}">{{ .Title }}</div>
+        {{ else }}
+        {{ $talkLink := (.Params.externalLink | default .Permalink) }}
+        <a href="{{ $talkLink }}" class="talk__title" data-title-wrap="{{ $titleWrap | default "wrap"}}" data-dir="{{ $.Param "languagedir" | default "ltr" }}">{{ .Title }}</a>
+        {{ end }}
       </li>
       {{ end }}
     </ul>


### PR DESCRIPTION
Quite often in my case, there is no content that I would like to
provide on a dedicated page for a particular page. As a result
I would like to be able to disable the link at all or provide an
external link (e.g. to the conference page).

Btw, it is possible to reduce duplication by assigning `div` or `a` to a variable, but I'm not sure how readable it would be.

My CSS skills are too limited, but as an extension you might want to add two more parameters: `slidesLink` and `videoLink` which - if available - would cause a slides icon and/or a move icon to be displayed next to the talk name (in the lists with talks), linked to provided materials. WDYT?