### PR TITLE
Ability to disable link do talk page or provide external one

### DIFF
--- a/layouts/talks/list.html
+++ b/layouts/talks/list.html
@@ -22,7 +22,11 @@
         <span class="talk__date" data-dir="{{ $.Param "languagedir" | default "ltr" }}">
           {{ .PublishDate.Format (i18n "talks-dateformat") }}
         </span>
-        <a href="{{ .Permalink }}" class="talk__title" data-title-wrap="{{ $titleWrap | default "wrap"}}" data-dir="{{ $.Param "languagedir" | default "ltr" }}">{{ .Title }}</a>
+        {{ if .Params.disableLink }}
+        <div class="talk__title" data-title-wrap="{{ $titleWrap | default "wrap"}}" data-dir="{{ $.Param "languagedir" | default "ltr" }}">{{ .Title }}</div>
+        {{ else }}
+        <a href="{{ if .Params.externalLink }}{{ .Params.externalLink }}{{ else }}{{ .Permalink }}{{ end }}" class="talk__title" data-title-wrap="{{ $titleWrap | default "wrap"}}" data-dir="{{ $.Param "languagedir" | default "ltr" }}">{{ .Title }}</a>
+        {{ end }}
       </li>
       {{ end }}
     </ul>


### PR DESCRIPTION
Quite often in my case, there is no content that I would like to
provide on a dedicated page for a particular page. As a result
I would like to be able to disable the link at all or provide an
external link (e.g. to the conference page).

The second try, as discussed in https://github.com/zzossig/hugo-theme-zzo/pull/166#issuecomment-585808604.