### PR TITLE
Send optional favicons only if provided

### DIFF
--- a/layouts/partials/head/meta.html
+++ b/layouts/partials/head/meta.html
@@ -54,8 +54,12 @@
   <meta name="msapplication-TileColor" content="#ffffff">
   <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
 {{ else }}
+  {{ if (fileExists "static/apple-touch-icon.png") -}}
   <link rel="apple-touch-icon" href="{{ "apple-touch-icon.png" | relURL }}">
-  <link rel="shortcut icon" href="{{ "favicon.png" | relURL }}" type="image/x-icon">
+  {{- end }}
   <link rel="shortcut icon" href="{{ "favicon.ico" | relURL }}" type="image/x-icon">
+  <link rel="icon" href="{{ "favicon.png" | relURL }}" sizes="any" type="image/png" />
+  {{ if (fileExists "static/logo.svg") -}}
   <link rel="icon" href="{{ "logo.svg" | relURL }}" sizes="any" type="image/svg+xml" />
+  {{- end }}
 {{ end }}


### PR DESCRIPTION
For instance always sending logo.svg link at the last position breaks
displaying favicon in Firefox if that file is missing (even if
previously precised png is available).

Btw, in the [documentation](https://gohugo.io/functions/fileexists/) there was `-}}` used. I haven't found how if differs.