### PR TITLE
Do not display empty series and categories in sidebar

### DIFF
--- a/layouts/partials/taxonomy/taxonomy-categories.html
+++ b/layouts/partials/taxonomy/taxonomy-categories.html
@@ -1,4 +1,4 @@
-{{ if $.Param "enableSidebarCategories" }}
+{{ if and ($.Param "enableSidebarCategories") (ne (len .Site.Taxonomies.categories) 0) }}
 <div class="taxo">
     <section>
         <span class="title p2">

--- a/layouts/partials/taxonomy/taxonomy-series.html
+++ b/layouts/partials/taxonomy/taxonomy-series.html
@@ -1,4 +1,4 @@
-{{ if $.Param "enableSidebarSeries" }}
+{{ if and ($.Param "enableSidebarSeries") (ne (len .Site.Taxonomies.series) 0) }}
 <div class="taxo">
     <section>
         <span class="title p2">


### PR DESCRIPTION
I encounter it having no series in my blog (yet). I don't want to disable it permanently as locally I experiment with series and other stuff. Checking if there is any series (or category) to display in the sidebar seems sensible for me.

I don't know if it makes sense also for categories (who don't use it? :-) ), but I added it along the way.

There is one minor caveat. If someone defines an empty series, e.g.
```
series:
- 
```

then the title is displayed (as there is one series), but it is filtered out later on. However, it works the same way right now.
