### PR TITLE
Use canonicalUrl parameter for canonical tag in meta headers

### DIFF
--- a/layouts/partials/head/meta.html
+++ b/layouts/partials/head/meta.html
@@ -54,7 +54,11 @@
 <meta name="msapplication-navbutton-color" content="{{ $.Scratch.Get "themeNavbarColor" | default "#fff" }}">
 <!-- iOS Safari -->
 <meta name="apple-mobile-web-app-status-bar-style" content="{{ $.Scratch.Get "themeNavbarColor" | default "#fff" }}">
+{{ if $.Param "canonicalUrl" }}
+<link rel="canonical" href="{{ $.Param "canonicalUrl" | absLangURL }}">
+{{ else }}
 <link rel="canonical" href="{{ .Permalink | absLangURL }}">
+{{ end }}
 <link rel="manifest" href="{{ "manifest.json" | relURL }}">
 {{ if $.Site.Params.useFaviconGenerator }}
   <link rel="apple-touch-icon" sizes="57x57" href="{{ "favicon/apple-icon-57x57.png" | relURL }}">


### PR DESCRIPTION
If defined. Fallback to .Permalink as before.

Useful for example to provide a copy of an article on your personal blog which is officially published on the company blog, without a [SEO penalty](https://yoast.com/rel-canonical/) for the main article. 