### PR TITLE
Use tags as keywords if keywords not defined

### DIFF
--- a/layouts/partials/head/meta.html
+++ b/layouts/partials/head/meta.html
@@ -2,7 +2,11 @@
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" title="{{ .Name }}" href="{{ .Permalink | safeURL }}">
 {{ end }}
 <meta name="description" content="{{ $.Param "description" }}" />
+{{ if isset .Params "keywords" }}
 <meta name="keywords" content="{{ delimit .Keywords "," }}">
+{{ else if isset .Params "tags" }}
+<meta name="keywords" content="{{ delimit .Params.tags "," }}">
+{{ end }}
 <meta name="created" content="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">
 <meta name="modified" content="{{ .Lastmod.Format "2006-01-02T15:04:05-0700" }}">
 <meta property="article:published_time" content="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">


### PR DESCRIPTION
Very often keywords are not defined at all, so it's better
to reuse tags that nothing (omitting the fact if keywords
are used by anything).