### PR TITLE
Fix issue with tags/keywords not set

### DIFF
--- a/layouts/partials/head/meta.html
+++ b/layouts/partials/head/meta.html
@@ -3,9 +3,13 @@
 {{ end }}
 <meta name="description" content="{{ $.Param "description" }}" />
 {{ if isset .Params "keywords" }}
-<meta name="keywords" content="{{ delimit .Keywords "," }}">
+  {{ with $.Params.keywords }}
+  <meta name="keywords" content="{{ delimit $.Params.keywords "," }}">
+  {{ end }}
 {{ else if isset .Params "tags" }}
-<meta name="keywords" content="{{ delimit .Params.tags "," }}">
+  {{ with $.Params.tags }}
+  <meta name="keywords" content="{{ delimit $.Params.tags "," }}">
+  {{ end }}
 {{ end }}
 <meta name="created" content="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">
 <meta name="modified" content="{{ .Lastmod.Format "2006-01-02T15:04:05-0700" }}">

--- a/layouts/partials/head/meta.html
+++ b/layouts/partials/head/meta.html
@@ -2,14 +2,11 @@
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" title="{{ .Name }}" href="{{ .Permalink | safeURL }}">
 {{ end }}
 <meta name="description" content="{{ $.Param "description" }}" />
-{{ if isset .Params "keywords" }}
-  {{ with $.Params.keywords }}
-  <meta name="keywords" content="{{ delimit $.Params.keywords "," }}">
-  {{ end }}
-{{ else if isset .Params "tags" }}
-  {{ with $.Params.tags }}
-  <meta name="keywords" content="{{ delimit $.Params.tags "," }}">
-  {{ end }}
+{{ with $.Params.keywords }}
+<meta name="keywords" content="{{ delimit $.Params.keywords "," }}">
+{{ end }}
+{{ with $.Params.tags }}
+<meta name="keywords" content="{{ delimit $.Params.tags "," }}">
 {{ end }}
 <meta name="created" content="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">
 <meta name="modified" content="{{ .Lastmod.Format "2006-01-02T15:04:05-0700" }}">


### PR DESCRIPTION
If keywords/tags were not set/defined at all, the build would fail.

```
Building sites … ERROR 2020/03/03 21:49:08 render of "page" failed: execute of template failed: template: gallery/single.html:11:7: executing "gallery/single.html" at <partial "head/meta" .>: error calling partial: "../themes/zzo/layouts/partials/head/meta.html:8:34": execute of template failed: template: partials/head/meta.html:8:34: executing "partials/head/meta.html" at <delimit .Params.tags ",">: error calling delimit: can't iterate over <nil>
Total in 2911 ms
Error: Error building site: failed to render pages: render of "page" failed: execute of template failed: template: gallery/single.html:11:7: executing "gallery/single.html" at <partial "head/meta" .>: error calling partial: ../themes/zzo/layouts/partials/head/meta.html:8:34": execute of template failed: template: partials/head/meta.html:8:34: executing "partials/head/meta.html" at <delimit .Params.tags ",">: error calling delimit: can't iterate over <nil>
```
This happened mostly for gallery pages for me, right after I updated from master. I guess the last merge didn't consider this particular case.

Fixed in this :tada: 
