### PR TITLE
Display modification date only if different than creation date

### DIFF
--- a/layouts/partials/body/infos.html
+++ b/layouts/partials/body/infos.html
@@ -1,6 +1,13 @@
 {{ $params := .Params }}
 <div class="single__infos">
-  <time class="single__info" title="{{ i18n "tooltip-written" }}">📅&nbsp;{{ .Date.Format (i18n "single-dateformat") }} </time> {{ if .GitInfo }} &nbsp;&nbsp; <time class="single__info" title="{{ i18n "tooltip-modified" }}"> 📝{{ .Lastmod.Format (i18n "single-dateformat") }} </time> {{ end }} &middot; <span class="single__info" title="{{ i18n "tooltip-reading-time" }}"> ☕ {{ .ReadingTime }} {{ i18n "reading-time" }} </span>{{ with .Params.Author }}&middot; <span class="single__info" title="{{ i18n "single-writtenBy" }}">{{if $params.AuthorEmoji }}{{ $params.AuthorEmoji }}{{ else }}✍️{{ end }}&nbsp;{{ . }}</span>{{ end }}
+  <time class="single__info" title="{{ i18n "tooltip-written" }}">📅&nbsp;{{ .Date.Format (i18n "single-dateformat") }} </time>
+  {{ if ne (.Date.Format (i18n "summary-dateformat")) (.Lastmod.Format (i18n "summary-dateformat")) }}
+  &nbsp;&nbsp; <time class="single__info" title="{{ i18n "tooltip-modified" }}"> 📝{{ .Lastmod.Format (i18n "single-dateformat") }} </time>
+  {{ end }}
+  &middot; <span class="single__info" title="{{ i18n "tooltip-reading-time" }}"> ☕ {{ .ReadingTime }} {{ i18n "reading-time" }} </span>
+  {{ with .Params.Author }}
+  &middot; <span class="single__info" title="{{ i18n "single-writtenBy" }}">{{if $params.AuthorEmoji }}{{ $params.AuthorEmoji }}{{ else }}✍️{{ end }}&nbsp;{{ . }}</span>
+  {{ end }}
   <span class="single__info">
     {{ if (and .Site.Params.enableBusuanzi .Site.Params.busuanziPagePV) }} &middot; 👀<span id="busuanzi_value_page_pv">...</span> {{ i18n "counter-page-pv" }}{{ end }}
   </span>

--- a/layouts/partials/summary/classic.html
+++ b/layouts/partials/summary/classic.html
@@ -18,7 +18,14 @@
     <div class="summary-classic__content">
       <header>
         <h5 class="title h5"><a href='{{ .Permalink }}'> {{ .Title }}</a> </h5>
-        <h6 class="subtitle caption"><time title="{{ i18n "tooltip-written" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}">📅 {{ .Date.Format (i18n "summary-dateformat") }} </time> {{ if .GitInfo }} <time title="{{ i18n "tooltip-modified" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}"> &middot; 📝 {{ .Lastmod.Format (i18n "summary-dateformat") }} </time> {{ end }} <span title="{{ i18n "tooltip-reading-time" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}"> &middot; ☕ {{ .ReadingTime }} {{ i18n "reading-time" }} </span>{{ with $.Param "author" }}&middot; <span title="{{ i18n "single-writtenBy" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}">{{if $.Param "authorEmoji" }}{{ $.Param "authorEmoji" }}{{ else }}✍️{{ end }}&nbsp;{{ . }}</span>{{ end }}</h6>
+        <h6 class="subtitle caption">
+          <time title="{{ i18n "tooltip-written" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}">📅 {{ .Date.Format (i18n "summary-dateformat") }} </time>
+          {{ if ne (.Date.Format (i18n "summary-dateformat")) (.Lastmod.Format (i18n "summary-dateformat")) }}
+          <time title="{{ i18n "tooltip-modified" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}"> &middot; 📝 {{ .Lastmod.Format (i18n "summary-dateformat") }} </time>
+          {{ end }}
+          <span title="{{ i18n "tooltip-reading-time" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}"> &middot; ☕ {{ .ReadingTime }} {{ i18n "reading-time" }} </span>
+          {{ with $.Param "author" }}&middot; <span title="{{ i18n "single-writtenBy" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}">{{if $.Param "authorEmoji" }}{{ $.Param "authorEmoji" }}{{ else }}✍️{{ end }}&nbsp;{{ . }}</span>{{ end }}
+        </h6>
       </header>
       <div>
         <div class="summary-classic__text p2">


### PR DESCRIPTION
It rather doesn't make sense to display a separate modification date it the same as the creation date. The new solution also takes into account `.lastmod` set in file, not only `.GitInfo` (which still has precedence in default configuration).

I split that into more lines as it was very problematic to grasp as one-liner.

I realize that it has to be applied also in `card.html` and `compact.html`, but there are subtle differences in formatting and param and you have to decide which you prefer.
