### PR TITLE
[ZZO] Add &nbsp; in post date/reading time

### DIFF
--- a/layouts/partials/body/infos.html
+++ b/layouts/partials/body/infos.html
@@ -2,11 +2,11 @@
 <div class="single__infos">
   <time class="single__info" title="{{ i18n "tooltip-written" }}">📅&nbsp;{{ .Date.Format (i18n "single-dateformat") }} </time>
   {{ if ne (.Date.Format (i18n "summary-dateformat")) (.Lastmod.Format (i18n "summary-dateformat")) }}
-  &nbsp;&nbsp; <time class="single__info" title="{{ i18n "tooltip-modified" }}"> 📝{{ .Lastmod.Format (i18n "single-dateformat") }} </time>
+  &nbsp;&middot;&nbsp; <time class="single__info" title="{{ i18n "tooltip-modified" }}"> 📝&nbsp;{{ .Lastmod.Format (i18n "single-dateformat") }} </time>
   {{ end }}
-  &middot; <span class="single__info" title="{{ i18n "tooltip-reading-time" }}"> ☕ {{ .ReadingTime }} {{ i18n "reading-time" }} </span>
+  &nbsp;&middot;&nbsp; <span class="single__info" title="{{ i18n "tooltip-reading-time" }}"> ☕&nbsp;{{ .ReadingTime }}&nbsp;{{ i18n "reading-time" }} </span>
   {{ with .Params.Author }}
-  &middot; <span class="single__info" title="{{ i18n "single-writtenBy" }}">{{if $params.AuthorEmoji }}{{ $params.AuthorEmoji }}{{ else }}✍️{{ end }}&nbsp;{{ . }}</span>
+  &nbsp;&middot;&nbsp; <span class="single__info" title="{{ i18n "single-writtenBy" }}">{{if $params.AuthorEmoji }}{{ $params.AuthorEmoji }}{{ else }}✍️{{ end }}&nbsp;{{ . }}</span>
   {{ end }}
   <span class="single__info">
     {{ if (and .Site.Params.enableBusuanzi .Site.Params.busuanziPagePV) }} &middot; 👀<span id="busuanzi_value_page_pv">...</span> {{ i18n "counter-page-pv" }}{{ end }}

--- a/layouts/partials/summary/classic.html
+++ b/layouts/partials/summary/classic.html
@@ -19,11 +19,11 @@
       <header>
         <h5 class="title h5"><a href='{{ .Permalink }}'> {{ .Title }}</a> </h5>
         <h6 class="subtitle caption">
-          <time title="{{ i18n "tooltip-written" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}">📅 {{ .Date.Format (i18n "summary-dateformat") }} </time>
+          <time title="{{ i18n "tooltip-written" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}">📅&nbsp;{{ .Date.Format (i18n "summary-dateformat") }} </time>
           {{ if ne (.Date.Format (i18n "summary-dateformat")) (.Lastmod.Format (i18n "summary-dateformat")) }}
-            <time title="{{ i18n "tooltip-modified" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}"> &middot; 📝 {{ .Lastmod.Format (i18n "summary-dateformat") }} </time>
+          <time title="{{ i18n "tooltip-modified" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}"> &middot; 📝&nbsp;{{ .Lastmod.Format (i18n "summary-dateformat") }} </time>
           {{ end }}
-          <span title="{{ i18n "tooltip-reading-time" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}"> &middot; ☕ {{ .ReadingTime }} {{ i18n "reading-time" }} </span>
+          <span title="{{ i18n "tooltip-reading-time" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}"> &middot; ☕&nbsp;{{ .ReadingTime }}&nbsp;{{ i18n "reading-time" }} </span>
           {{ with $.Param "author" }}
           &middot; <span title="{{ i18n "single-writtenBy" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}">{{ if $.Param "authorEmoji" }}{{ $.Param "authorEmoji" }}{{ else }}✍️{{ end }}&nbsp;{{ . }}</span>
           {{ end }}


### PR DESCRIPTION
A coffee icon in a separate row looks somehow odd on mobile.

Along the way I also increased spacing around &middot; in the post view and unified it. Feel free to remove the second change if you don't like it.