### PR TITLE
Update _publication.scss to fix bad initial layout on mobile

### DIFF
--- a/assets/sass/pages/_publication.scss
+++ b/assets/sass/pages/_publication.scss
@@ -205,6 +205,13 @@
   width: 49.5%;
 }
 
+@media only screen and (max-width:769px) {
+  .pgrid-sizer,
+  .pgrid-item {
+    width: 100%;
+  }
+}
+
 .pgrid-item {
   float: left;
   border-radius: 0.25rem;


### PR DESCRIPTION
Added media query to complement the full/half pgrid-item dynamic resizing on loading.
Fixes #261 