### PR TITLE
Message about ability to comment directly via GitHub for Utterances

### DIFF
--- a/layouts/partials/comments/utterances.html
+++ b/layouts/partials/comments/utterances.html
@@ -27,3 +27,10 @@
     }
   });
 </script>
+
+<div id="comments-fallback" class="viaemail">
+    <div class="viaemail__no-comments-message">
+        Don't want to use the Utterance bot? Comments can be also placed
+        <a href="https://github.com/{{ .Site.Params.utterances.owner }}/{{ .Site.Params.utterances.repo }}/issues/{{ .Params.utterances_issue_id | default "" }}" target="_blank" rel="noreferrer">directly on GitHub</a>.
+    </div>
+</div>


### PR DESCRIPTION
Utterances is nice to leverage GitHub as a storage for comments, however, not all people are happy to have to authorize the Utterances bot to put comments everywhere on GitHub on their behalves.

This PR adds a message below the comment iframe with the information where the comments can be placed directly. It points to the generic configured issues link for site or (if `utterances_issue_id: X` is defined for a given page) also points directly to the particular issues.

I (re-)use my custom CSS classes here, so you would probably want to add some own.

Sample appearances:
![image](https://user-images.githubusercontent.com/148013/81071038-6cf67400-8ee4-11ea-8c92-6ba3821847f6.png)

Btw, what is also nice, it works also if external scripts (for utterances) are blocked in the browser.