### PR TITLE
Fixed cite.bib not found

### DIFF
--- a/layouts/partials/publication/pub-links.html
+++ b/layouts/partials/publication/pub-links.html
@@ -19,7 +19,7 @@
         {{ partial "svgs/etc/close.svg" (dict "width" 25 "height" 25) }}
       </div>
       <main class="modal__cite">
-        {{ $filePath := (print .Permalink "cite.bib" | relLangURL) }}
+        {{ $filePath := print "/content" (print .Permalink "cite.bib" | relURL) }}
         {{ if fileExists $filePath }}
           <div class="modal__cite--exist" id="citeContents">
             {{ readFile $filePath | markdownify }}


### PR DESCRIPTION
A problem was that, even there is cite.bib, it tells that there is no cite.bib. The reason was, the reference was to /en/en/... So I fixed it.