### PR TITLE
Fixed empty string parse error in meta_json_id.html

### DIFF
--- a/layouts/partials/head/meta_json_ld.html
+++ b/layouts/partials/head/meta_json_ld.html
@@ -7,7 +7,7 @@
     "datePublished": {{ .Date.Format "2006-01-02T15:04:05Z07:00" }},
     "dateModified": {{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" }},
     "url" : {{ .Permalink }},
-    "description": {{ with (.Description | default (replaceRE "\n" " " (.Summary | truncate 170))) }}{{ . }}{{ end }},
+    "description": "{{ with (.Description | default (replaceRE "\n" " " (.Summary | truncate 170))) }}{{ . }}{{ end }}",
     {{ with .Params.tags -}}
     "keywords": {{ . }},
     {{ end -}}
@@ -16,7 +16,7 @@
     "url" : {{ .Permalink }},
     "name": {{ .Title }},
     {{ with $.Param "description" -}}
-    "description": {{ . }},
+    "description": "{{ . }}",
     {{ end -}}
     {{ end -}}
     {{ with $.Param "image" -}}


### PR DESCRIPTION
Hugo throws error while building if I do not give any description. Because the description were becoming only `"description": ,` which is invalid. FIxed it by wraping which will give `"description": "",` which is valid.