### PR TITLE
Removes extra slash (/)

### DIFF
--- a/layouts/partials/footer/links-feed.html
+++ b/layouts/partials/footer/links-feed.html
@@ -2,7 +2,7 @@
   {{ if not (in ($.Param "notAllowedTypesInHomeFeed") .Type) }}
   {{ $exclude := slice "tags" "series" "categories" }}
     {{ if not (in $exclude .Type) }}
-      <a href="{{ if eq hugo.Version "0.65.2" }}{{ .CurrentSection.FirstSection.Permalink }}{{ else }}{{ .FirstSection.Permalink }}{{ end }}/index.xml" type="application/rss+xml" title="RSS" aria-label="RSS Feed Link">
+      <a href="{{ if eq hugo.Version "0.65.2" }}{{ .CurrentSection.FirstSection.Permalink }}{{ else }}{{ .FirstSection.Permalink }}{{ end }}index.xml" type="application/rss+xml" title="RSS" aria-label="RSS Feed Link">
         {{ partial "svgs/etc/rss.svg" (dict "width" 32 "height" 32) }}
       </a>
     {{ else }}


### PR DESCRIPTION
The current link for the RSS feed link on the [Posts page](https://themes.gohugo.io//theme/hugo-theme-zzo/en/posts) renders as `/theme/hugo-theme-zzo/en/posts**//**index.xml`. This was causing 404 errors when serving from a Google Cloud Storage bucket. This PR removes that extra slash (/) which fixed those errors for me on all pages with an RSS feed.