### PR TITLE
Language selector change theme fix

### DIFF
--- a/layouts/partials/navbar/language-icon.html
+++ b/layouts/partials/navbar/language-icon.html
@@ -3,7 +3,7 @@
     <button class="dropdown-trigger navbar__slide-down" aria-label="Select Language Button" data-ani="{{ $.Site.Params.enableUiAnimation | default "true" }}">
       {{ partial "svgs/etc/translate.svg" (dict "width" 22 "height" 22) }}      
     </button>
-    <div class="dropdown-content select-theme">
+    <div class="dropdown-content">
       {{ $siteLanguages := .Site.Languages }}
       {{ $pageLang := .Page.Lang }}
       {{ range .Page.AllTranslations }}
@@ -13,11 +13,11 @@
           {{ $selected := false }}
             {{ if eq $pageLang .Lang }}
               {{ if .LanguageName }}
-                <a href="{{ $translation.Permalink }}" data-lang="{{ .Lang }}" class="dropdown-item select-theme__item is-active">{{ .LanguageName }}</a>
+                <a href="{{ $translation.Permalink }}" data-lang="{{ .Lang }}" class="dropdown-item is-active">{{ .LanguageName }}</a>
               {{ end }}
             {{ else }}
               {{ if .LanguageName }}
-                <a href="{{ $translation.Permalink }}" data-lang="{{ .Lang }}" class="dropdown-item ">{{ .LanguageName }}</a>
+                <a href="{{ $translation.Permalink }}" data-lang="{{ .Lang }}" class="dropdown-item">{{ .LanguageName }}</a>
               {{ end }}
             {{ end }}
           {{ end }}

--- a/layouts/partials/navbar/search-icon.html
+++ b/layouts/partials/navbar/search-icon.html
@@ -3,7 +3,7 @@
     <button class="dropdown-trigger navbar__slide-down navbar-search" aria-label="Search Button" data-ani="{{ $.Site.Params.enableUiAnimation | default "true" }}">
       {{ partial "svgs/etc/search.svg" (dict "width" 22 "height" 22) }}
     </button>
-    <div class="dropdown-content select-theme">
+    <div class="dropdown-content">
     </div>
   </div>
 </div>


### PR DESCRIPTION
Similar to #334. If the user clicks on the same language twice, it will save to `localStorage` the name of the language because of the `select-theme` selector that is also applied to the language chooser.