### PR TITLE
Add year Replacement in RSS copyright

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -13,7 +13,7 @@
     <language>{{.}}</language>{{end}}{{ with $.Site.Params.email }}
     <managingEditor>{{.}}{{ with $.Site.Params.myname }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.email }}
     <webMaster>{{.}}{{ with $.Site.Params.myname }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
-    <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
+    <copyright>{{ replace . "{year}" now.Year | markdownify}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}{{ with .Site.Params.updatePeriod }}
     <sy:updatePeriod>{{.}}</sy:updatePeriod>{{end}}{{ with .Site.Params.updateFrequency }}
     <sy:updateFrequency>{{.}}</sy:updateFrequency>{{end}}


### PR DESCRIPTION
Added the same replacement that happens in site-footer.html for the copyright to the RSS feed template