### PR TITLE
Fix 'undefined' href in search results without highlight

### DIFF
--- a/layouts/partials/head/scripts.html
+++ b/layouts/partials/head/scripts.html
@@ -722,7 +722,7 @@
       var a = document.createElement('a');
       a.innerHTML = obj.item.title;
       a.setAttribute('class', 'search-result__item--title');
-      a.setAttribute('href', obj.item.permalink);
+      a.setAttribute('href', obj.item.uri);
 
       var descDiv = document.createElement('div');
       descDiv.setAttribute('class', 'search-result__item--desc');


### PR DESCRIPTION
If `enableSearchHighlight = false` is set in `params.toml`,
populated search results using the side search will use the `makeLi` function to set `href` to `obj.item.permalink` as opposed to `obj.item.uri` when the `makeHighlightLi` function is used.
`obj.item.permalink` used will result in `undefined `attribute and invalid links.

![chrome_2021-05-03_17-14-50](https://user-images.githubusercontent.com/16717153/116861362-8fc18280-ac35-11eb-80df-24fdb96c45fa.png)
