### PR TITLE
Don't translate theme names into German

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -107,13 +107,13 @@ other = "Dunkel"
 other = "Hell"
 
 [skin-hacker]
-other = "Schwarz/Grün"
+other = "Hacker"
 
 [skin-solarized]
-other = "Samtig Hell"
+other = "Solarized"
 
 [skin-kimbie]
-other = "Braun"
+other = "Kimbie"
 
 [no-contents]
 other = "Hier gibt es nichts zu sehen!"


### PR DESCRIPTION
I have noticed that a German translation has been added, for which I am very grateful. :)
However, I would like to suggest not translating the names of the themes, as they are proper names.