### PR TITLE
support custom issue-term for utterances 

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -127,7 +127,7 @@ commento = false
 [utterances]       # https://utteranc.es/
   owner = ""              # Your GitHub ID
   repo = ""               # The repo to store comments
-  issueTerm =""            # Choose the mapping between blog posts and GitHub issues. pathname (default), title, url, og:title...
+  issueTerm = ""            # Choose the mapping between blog posts and GitHub issues. pathname (default), title, url, og:title...
 
 [gitalk]           # Gitalk is a comment system based on GitHub issues. see https://github.com/gitalk/gitalk
   owner = ""              # Your GitHub ID

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -127,6 +127,7 @@ commento = false
 [utterances]       # https://utteranc.es/
   owner = ""              # Your GitHub ID
   repo = ""               # The repo to store comments
+  issueTerm =""            # Choose the mapping between blog posts and GitHub issues. pathname (default), title, url, og:title...
 
 [gitalk]           # Gitalk is a comment system based on GitHub issues. see https://github.com/gitalk/gitalk
   owner = ""              # Your GitHub ID

--- a/layouts/partials/comments/utterances.html
+++ b/layouts/partials/comments/utterances.html
@@ -21,6 +21,8 @@
       var owner = JSON.parse({{ $owner | jsonify }});
       {{ $repo:= .Site.Params.utterances.repo }}
       var repo = JSON.parse({{ $repo | jsonify }});
+      {{ $issueTerm:= .Site.Params.utterances.issueTerm | default 'pathname' }}
+      var issueTerm = JSON.parse({{ $issueTerm | jsonify }});
       {{ $baseTheme:= index .Site.Params.themeOptions 0 }}
       var baseTheme = JSON.parse({{ $baseTheme | jsonify }});
       var localTheme = localStorage.getItem('theme');
@@ -28,7 +30,7 @@
       var myScript = document.createElement('script');
       myScript.setAttribute('src', 'https://utteranc.es/client.js');
       myScript.setAttribute('repo', `${owner}/${repo}`);
-      myScript.setAttribute('issue-term', 'pathname');
+      myScript.setAttribute('issue-term', issueTerm);
       myScript.setAttribute('theme', utterTheme);
       myScript.setAttribute('crossorigin', 'anonymous');
       myScript.setAttribute('async', '');

--- a/layouts/partials/comments/utterances.html
+++ b/layouts/partials/comments/utterances.html
@@ -21,7 +21,7 @@
       var owner = JSON.parse({{ $owner | jsonify }});
       {{ $repo:= .Site.Params.utterances.repo }}
       var repo = JSON.parse({{ $repo | jsonify }});
-      {{ $issueTerm:= .Site.Params.utterances.issueTerm | default 'pathname' }}
+      {{ $issueTerm:= .Site.Params.utterances.issueTerm | default "pathname" }}
       var issueTerm = JSON.parse({{ $issueTerm | jsonify }});
       {{ $baseTheme:= index .Site.Params.themeOptions 0 }}
       var baseTheme = JSON.parse({{ $baseTheme | jsonify }});


### PR DESCRIPTION
Add a configuration item `Params.utterances.issueTerm` to **choose the mapping between blog posts and GitHub issues**, its default value is `pathname`.

see https://utteranc.es

![Snipaste_2021-09-14_22-55-58](https://user-images.githubusercontent.com/26341224/133332661-e066a812-e896-40b5-b177-7e8dc32cbc15.png)

Config (params.toml):
```
[utterances]       # https://utteranc.es/
  owner = ""              # Your GitHub ID
  repo = ""               # The repo to store comments
  issueTerm =""           # Choose the mapping between blog posts and GitHub issues. pathname (default), title, url, og:title...
  message = ""      # Optional
  link = ""         # Optional
```
