### PR TITLE
feat: render markdown hooks in shortcodes

### DIFF
--- a/layouts/shortcodes/alert.html
+++ b/layouts/shortcodes/alert.html
@@ -1,1 +1,1 @@
-<div class="alert {{ with .Get "theme" }}alert-{{.}}{{ end }}" role="alert" data-dir="{{ with .Get "dir" }}{{.}}{{ else }}ltr{{ end }}">{{ .Inner | markdownify }}</div>
+<div class="alert {{ with .Get "theme" }}alert-{{.}}{{ end }}" role="alert" data-dir="{{ with .Get "dir" }}{{.}}{{ else }}ltr{{ end }}">{{ .Inner | .Page.RenderString }}</div>

--- a/layouts/shortcodes/boxmd.html
+++ b/layouts/shortcodes/boxmd.html
@@ -1,1 +1,1 @@
-<div class="box">{{ .Inner | markdownify }}</div>
+<div class="box">{{ .Inner | .Page.RenderString }}</div>

--- a/layouts/shortcodes/button.html
+++ b/layouts/shortcodes/button.html
@@ -1,5 +1,5 @@
 <a href="{{ .Get "href" | default "#" }}" class="button" style="width: {{ .Get "width" | default "72px" }}; height: {{ .Get "height" | default "30px" }};" data-color="{{ .Get "color" | default "default" }}" target="_blank" rel="noreferrer">
   <span class="button__text">
-    {{ .Inner | markdownify }}
+    {{ .Inner | .Page.RenderString }}
   </span>
 </a>

--- a/layouts/shortcodes/code.html
+++ b/layouts/shortcodes/code.html
@@ -1,4 +1,4 @@
 {{ $id := substr (md5 .Inner) 0 16 }}
 <div id="{{ $id }}" class="codetab__content">
-  {{ .Inner | markdownify }}
+  {{ .Inner | .Page.RenderString }}
 </div>

--- a/layouts/shortcodes/color.html
+++ b/layouts/shortcodes/color.html
@@ -1,1 +1,1 @@
-<span style="color: {{ .Get 0 | default "#f48fb1" }}">{{ .Inner | markdownify }}</span>
+<span style="color: {{ .Get 0 | default "#f48fb1" }}">{{ .Inner | .Page.RenderString }}</span>

--- a/layouts/shortcodes/expand.html
+++ b/layouts/shortcodes/expand.html
@@ -6,6 +6,6 @@
     {{ .Get 0 }}
   </button>
   <div class="expand__content">
-    {{ .Inner | markdownify }}
+    {{ .Inner | .Page.RenderString }}
   </div>
 </div>

--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -1,3 +1,3 @@
 <div class="notices {{ .Get 0 }}" data-title="{{ .Get 1 | default (.Get 0) | humanize }}">
-  {{ .Inner | markdownify }}
+  {{ .Inner | .Page.RenderString }}
 </div>

--- a/layouts/shortcodes/swiperItem.html
+++ b/layouts/shortcodes/swiperItem.html
@@ -1,5 +1,5 @@
 <div class="swiper-slide" data-align="{{ .Get "align" | default "center" }}">
   <div class="swiper-slide__inner">
-    {{ .Inner | markdownify }}
+    {{ .Inner | .Page.RenderString }}
   </div>
 </div>

--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -1,4 +1,4 @@
 {{ $id := substr (md5 .Inner) 0 16 }}
 <div id="{{ $id }}" class="tab__content">
-  {{ .Inner | markdownify }}
+  {{ .Inner | .Page.RenderString }}
 </div>


### PR DESCRIPTION
Since v0.62, hugo added [`.Page.RenderString` function](https://gohugo.io/functions/renderstring/). This function has a huge advantage over `markdownify`: it triggers markdown hooks, that can be used to customize how some elements are rendered (such as links).

This PR use the new method in shortcodes.