### PR TITLE
feat: use official 'Language.LanguageDirection' parameter

### DIFF
--- a/exampleSite/config/_default/languages.toml
+++ b/exampleSite/config/_default/languages.toml
@@ -2,12 +2,12 @@
   title = "Hugo Zzo Theme"
   languageName = "English"
   weight = 1
-  languagedir = "ltr"
+  languageDirection = "ltr"
   contentdir = "content/en"
 
 [ko]
   title = "Hugo Zzo Theme"
   languageName = "한국어"
   weight = 2
-  languagedir = "ltr"
+  languageDirection = "ltr"
   contentdir = "content/ko"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.Language.Lang }}" dir="{{ $.Param "languagedir" | default "ltr" }}">
+<html lang="{{ .Site.Language.Lang }}" dir="{{ $.Site.Language.LanguageDirection | default "ltr" }}">
 
 <head prefix="og: http://ogp.me/ns#">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -22,7 +22,7 @@
     </div>    
 
     {{ if $.Param "enableSidebar" }}
-        <aside class="list__sidebar {{ if eq ($.Param "sidebarPosition") "left" }}l{{ else }}r{{ end }}" data-dir="{{ $.Param "languagedir" | default "ltr" }}">
+        <aside class="list__sidebar {{ if eq ($.Param "sidebarPosition") "left" }}l{{ else }}r{{ end }}" data-dir="{{ $.Site.Language.LanguageDirection | default "ltr" }}">
             {{ partial "sidebar/sidebar-list" . }}
         </aside>
     {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -20,7 +20,7 @@
       {{ partial "body/infos" . }}
       {{ partial "body/tags" . }}
     </div>
-    <article class="single__contents" data-dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}" data-ani="{{ $.Site.Params.enableUiAnimation | default "true" }}">
+    <article class="single__contents" data-dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}" data-ani="{{ $.Site.Params.enableUiAnimation | default "true" }}">
       {{ partial "body/toc" . }}
       {{ .Content }}
     </article>

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -21,7 +21,7 @@
   </div>
 
   {{ if $.Param "enableSidebar" }}
-    <aside class="list__sidebar {{ if eq ($.Param "sidebarPosition") "left" }}l{{ else }}r{{ end }}" data-dir="{{ $.Param "languagedir" | default "ltr" }}">
+    <aside class="list__sidebar {{ if eq ($.Param "sidebarPosition") "left" }}l{{ else }}r{{ end }}" data-dir="{{ $.Site.Language.LanguageDirection | default "ltr" }}">
       {{ partial "sidebar/sidebar-list" . }}
     </aside>
   {{ end }}

--- a/layouts/about/single.html
+++ b/layouts/about/single.html
@@ -5,7 +5,7 @@
   </h3>
 </header>
 <main class="main about">
-  <article class="single__contents single__contents--about" data-dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}" data-ani="{{ $.Site.Params.enableUiAnimation | default "true" }}">
+  <article class="single__contents single__contents--about" data-dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}" data-ani="{{ $.Site.Params.enableUiAnimation | default "true" }}">
     {{ .Content }}
   </article>
 </main>

--- a/layouts/archive/list.html
+++ b/layouts/archive/list.html
@@ -20,11 +20,11 @@
     {{ $paginator := .Paginate ($filteredPages.GroupByDate ($.Param "archiveGroupByDate" | default "2006")) ($.Param "archivePaginate") }}
     {{ range ($paginator).PageGroups }}
       <span class="archive__key" data-ani="{{ $.Site.Params.enableUiAnimation | default "true" }}">{{ .Key }}</span>
-      <ul class="archive__ul" data-dir="{{ $.Param "languagedir" | default "ltr" }}">
+      <ul class="archive__ul" data-dir="{{ $.Site.Language.LanguageDirection | default "ltr" }}">
         {{ range .Pages }}
-        <li class="archive__li" data-dir="{{ $.Param "languagedir" | default "ltr" }}">
+        <li class="archive__li" data-dir="{{ $.Site.Language.LanguageDirection | default "ltr" }}">
           <span class="archive__meta" data-ani="{{ $.Site.Params.enableUiAnimation | default "true" }}">
-            {{ if ne ($.Param "languagedir") "rtl" }}
+            {{ if ne $.Site.Language.LanguageDirection "rtl" }}
               <span class="archive__type">{{ .Type }}</span>
               <span class="archive__date">{{ .Date.Format (i18n "archive-dateformat") }}</span>
             {{ else }}
@@ -32,7 +32,7 @@
               <span class="archive__type">{{ .Type }}</span>
             {{ end }}
           </span>
-          <a href="{{ .Permalink }}" class="archive__title" data-title-wrap="{{ $titleWrap | default "wrap"}}" data-dir="{{ $.Param "languagedir" | default "ltr" }}">{{ .Title }}</a>        
+          <a href="{{ .Permalink }}" class="archive__title" data-title-wrap="{{ $titleWrap | default "wrap"}}" data-dir="{{ $.Site.Language.LanguageDirection | default "ltr" }}">{{ .Title }}</a>
         </li>
         {{ end }}
       </ul>

--- a/layouts/contact/single.html
+++ b/layouts/contact/single.html
@@ -6,7 +6,7 @@
 </header>
 <main class="main">
   <div class="contact">
-      <article class="single__contents contact__desc" data-dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}" data-ani="{{ $.Site.Params.enableUiAnimation | default "true" }}">
+      <article class="single__contents contact__desc" data-dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}" data-ani="{{ $.Site.Params.enableUiAnimation | default "true" }}">
         {{ .Content }}
       </article>
       {{ if eq .Params.service "formspree" }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -24,7 +24,7 @@
     </div>
 
     {{ if $.Param "enableSidebar" }}
-        <aside class="list__sidebar {{ if eq ($.Param "sidebarPosition") "left" }}l{{ else }}r{{ end }}" data-dir="{{ $.Param "languagedir" | default "ltr" }}">
+        <aside class="list__sidebar {{ if eq ($.Param "sidebarPosition") "left" }}l{{ else }}r{{ end }}" data-dir="{{ $.Site.Language.LanguageDirection | default "ltr" }}">
             {{ partial "sidebar/sidebar-home" . }}
         </aside>
     {{ end }}

--- a/layouts/partials/body/main-left.html
+++ b/layouts/partials/body/main-left.html
@@ -3,7 +3,7 @@
 {{ $isPad = or $isPad (and (eq .Kind "section") (eq .Type "publication")) }}
 {{ $isPad = or $isPad (and (eq .Type "tags") (ne .Kind "taxonomyTerm")) }}
 
-{{ if eq ($.Param "languagedir") "rtl" }}
+{{ if eq $.Site.Language.LanguageDirection "rtl" }}
 <div class="wrapper__left hide" data-pad="{{ $isPad }}" dir="rtl">
   <script>document.querySelector('.wrapper__left').classList.remove('hide')</script>
   {{ if and (eq ($.Param "tocPosition") "outer") .IsPage }}
@@ -25,7 +25,7 @@
     {{ end }}
   {{ end }}
 </div>
-{{ else if and (eq ($.Param "languagedir") "ltr") ($.Param "enableSidebarMenu") }}
+{{ else if and (eq $.Site.Language.LanguageDirection "ltr") ($.Param "enableSidebarMenu") }}
   <div class="wrapper__left" data-pad="{{ $isPad }}" dir="ltr">
     <div class="sidebar__menu">
       {{ partial "sidebar/sidebar-menu" . }}

--- a/layouts/partials/body/main-right.html
+++ b/layouts/partials/body/main-right.html
@@ -3,7 +3,7 @@
 {{ $isPad = or $isPad (and (eq .Kind "section") (eq .Type "publication")) }}
 {{ $isPad = or $isPad (and (eq .Type "tags") (ne .Kind "taxonomyTerm")) }}
 
-{{ if ne ($.Param "languagedir") "rtl" }}
+{{ if ne $.Site.Language.LanguageDirection "rtl" }}
 <div class="wrapper__right hide" data-pad="{{ $isPad }}" dir="ltr">
   <script>document.querySelector('.wrapper__right').classList.remove('hide')</script>
   {{ if and (eq ($.Param "tocPosition") "outer") .IsPage }}
@@ -25,7 +25,7 @@
     {{ end }}
   {{ end }}
 </div>
-{{ else if and (eq ($.Param "languagedir") "rtl") ($.Param "enableSidebarMenu") }}
+{{ else if and (eq $.Site.Language.LanguageDirection "rtl") ($.Param "enableSidebarMenu") }}
   <div class="wrapper__right" data-pad="{{ $isPad }}" dir="rtl">
     
   </div>

--- a/layouts/partials/navbar/nav-menu-mobile.html
+++ b/layouts/partials/navbar/nav-menu-mobile.html
@@ -8,7 +8,7 @@
   <span aria-hidden="true"></span>
 </a>
 <div class="navbarm__collapse" data-open="false">
-  <ul dir="{{ $.Param "languagedir" | default "ltr" }}">
+  <ul dir="{{ $.Site.Language.LanguageDirection | default "ltr" }}">
     {{ $current := . }}
     {{ range $index, $menu := .Site.Menus.main }}
       {{ $active := or ($current.IsMenuCurrent "main" $menu) ($current.HasMenuCurrent "main" $menu) }}

--- a/layouts/partials/navbar/nav-menu.html
+++ b/layouts/partials/navbar/nav-menu.html
@@ -15,18 +15,18 @@
   {{ if .HasChildren }}
   <div class="navbar__dropdown navbar__slide-down" data-ani="{{ $.Site.Params.enableUiAnimation | default "true" }}">
     <a href="{{ .URL | relLangURL }}" class="navbar__menu-item {{ if $active }}active{{ end }}"
-      dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}">
+      dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}">
       {{ safeHTML .Name }}
       {{ partial "svgs/arrow/keyboard-arrow-down.svg" (dict "width" 18 "height" 18) }}
     </a>
     <div class="navbar__dropdown--content">
       {{ range .Children }}
-      <a href="{{ .URL | relLangURL }}" class="navbar__dropdown--item" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}">{{ safeHTML .Name }}</a>
+      <a href="{{ .URL | relLangURL }}" class="navbar__dropdown--item" dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}">{{ safeHTML .Name }}</a>
       {{ end }}
     </div>
   </div>
   {{ else }}
-  <a href="{{ .URL | relLangURL }}" class="navbar__menu-item navbar__slide-down {{ if $active }}active{{ end }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}" data-ani="{{ $.Site.Params.enableUiAnimation | default "true" }}">{{ safeHTML .Name }}</a>
+  <a href="{{ .URL | relLangURL }}" class="navbar__menu-item navbar__slide-down {{ if $active }}active{{ end }}" dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}" data-ani="{{ $.Site.Params.enableUiAnimation | default "true" }}">{{ safeHTML .Name }}</a>
   {{ end }}
   {{ end }}
 </div>

--- a/layouts/partials/navbar/site-nav.html
+++ b/layouts/partials/navbar/site-nav.html
@@ -1,4 +1,4 @@
-<nav class="navbar scrolling" role="navigation" aria-label="main navigation" data-dir="{{ if $.Param "navbardir" }}{{ $.Param "navbardir" }}{{ else }}{{ $.Param "languagedir" | default "ltr" }}{{ end }}">
+<nav class="navbar scrolling" role="navigation" aria-label="main navigation" data-dir="{{ if $.Param "navbardir" }}{{ $.Param "navbardir" }}{{ else }}{{ $.Site.Language.LanguageDirection | default "ltr" }}{{ end }}">
   <div class="navbar__brand">
     {{ if $.Param "logo" | default true }}
     <a href="{{ "/" | relLangURL }}" title="{{ i18n "tooltip-home" }}" rel="home" class="{{ if eq ($.Param "logoType") "long" }}navbar__long-link{{ else }}navbar__logo-link{{ end }}">

--- a/layouts/partials/pagination/pagination-single.html
+++ b/layouts/partials/pagination/pagination-single.html
@@ -1,6 +1,6 @@
 <div class="grow"></div>
 <nav class="pagination-single">
-  {{ if eq ($.Param "languagedir") "rtl" }}
+  {{ if eq $.Site.Language.LanguageDirection "rtl" }}
     {{ with .NextInSection }}
     <a href="{{ .Permalink }}" class="pagination-single__right">
       <div class="pagination-single__icon">

--- a/layouts/partials/publication/pub-overview.html
+++ b/layouts/partials/publication/pub-overview.html
@@ -16,7 +16,7 @@
                 <div class="pub__box--desc">
                   {{ .Params.abstract }}
                 </div>
-                <div class="pub__box--links" data-dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}">
+                <div class="pub__box--links" data-dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}">
                   <a href="{{ .FirstSection.Permalink }}/{{ .Params.ENTRYTYPE }}">
                     🎯 {{ .Params.ENTRYTYPE }}
                   </a>

--- a/layouts/partials/script/single-script.html
+++ b/layouts/partials/script/single-script.html
@@ -362,7 +362,7 @@
     var text, clip = new ClipboardJS('.anchor');
     var headers = singleContentsElem.querySelectorAll("h1, h2, h3, h4");
 
-    {{ $languagedir := ($.Param "languagedir" | default "ltr") }}
+    {{ $languagedir := ($.Site.Language.LanguageDirection | default "ltr") }}
     var languagedir = JSON.parse({{ $languagedir | jsonify }});
 
     headers ? 

--- a/layouts/partials/search/search-result-desktop.html
+++ b/layouts/partials/search/search-result-desktop.html
@@ -1,6 +1,6 @@
 <div class="search-result" data-display="none">
   <div class="search-result__header">
-    <div class="search-result__close" data-dir="{{ if or (ne ($.Param "languagedir") "rtl") (eq ($.Param "sidebarPosition") "left") }}ltr{{ else }}rtl{{ end }}">
+    <div class="search-result__close" data-dir="{{ if or (ne $.Site.Language.LanguageDirection "rtl") (eq ($.Param "sidebarPosition") "left") }}ltr{{ else }}rtl{{ end }}">
       {{ partial "svgs/etc/cancel.svg" (dict "width" 28 "height" 28) }}
     </div>
   </div>

--- a/layouts/partials/search/site-search-mobile.html
+++ b/layouts/partials/search/site-search-mobile.html
@@ -3,7 +3,7 @@
   {{ partial "svgs/etc/search.svg" (dict "width" 22 "height" 22) }}
 </div>
 
-<div id="search-mobile-container" class="mobile-search hide" data-dir="{{ $.Param "languagedir" | default "ltr" }}">
+<div id="search-mobile-container" class="mobile-search hide" data-dir="{{ $.Site.Language.LanguageDirection | default "ltr" }}">
   <div class="mobile-search__top">
     <input id="search-mobile" type="text" aria-label="Mobile Search" placeholder="{{T "search-placeholder"}}" class="mobile-search__top--input"/>
     <div id="search-mobile-close" class="mobile-search__top--icon">

--- a/layouts/partials/showcase/show-pinned.html
+++ b/layouts/partials/showcase/show-pinned.html
@@ -12,7 +12,7 @@
         {{ $category := .Params.category }}
         {{ $categoryIcon := (print "svgs/showcase/" (.Params.categoryIcon | default "code") ".svg") }}
         {{ range where .Pages "Params.pinned" true }}
-          <li class="showcase__box" data-dir="{{ $.Param "languagedir" | default "ltr" }}">
+          <li class="showcase__box" data-dir="{{ $.Site.Language.LanguageDirection | default "ltr" }}">
             <a href="{{ .Params.Link }}" class="showcase__box--link" target="_blank" rel="noreferrer"></a>
             <span class="showcase__box--title">
               {{ .Title }}

--- a/layouts/partials/showcase/show-section.html
+++ b/layouts/partials/showcase/show-section.html
@@ -6,7 +6,7 @@
       {{ $category := .Params.category }}
       {{ $categoryIcon := (print "svgs/showcase/" (.Params.categoryIcon | default "code") ".svg") }}
       {{ range .Pages }}
-        <div class="showcase__box" data-dir="{{ $.Param "languagedir" | default "ltr" }}">
+        <div class="showcase__box" data-dir="{{ $.Site.Language.LanguageDirection | default "ltr" }}">
           <a href="{{ .Params.Link }}" class="showcase__box--link" target="_blank" rel="noreferrer"></a>
           <a href="{{ .Params.Link }}" class="showcase__box--title" target="_blank" rel="noreferrer">
             {{ .Title }}

--- a/layouts/partials/sidebar/sidebar-single.html
+++ b/layouts/partials/sidebar/sidebar-single.html
@@ -12,7 +12,7 @@
       </label>
     {{ end }}
   </div>
-  <div class="toc {{ if $.Param "hideToc" }}hide{{ end }}" data-dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}" data-folding="{{ if $.Param "tocFolding" }}true{{ else }}false{{ end }}" data-ani="{{ $.Site.Params.enableUiAnimation | default "true" }}">
+  <div class="toc {{ if $.Param "hideToc" }}hide{{ end }}" data-dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}" data-folding="{{ if $.Param "tocFolding" }}true{{ else }}false{{ end }}" data-ani="{{ $.Site.Params.enableUiAnimation | default "true" }}">
     {{ .TableOfContents }}
   </div>
 </section>

--- a/layouts/partials/sidebar/site-bio.html
+++ b/layouts/partials/sidebar/site-bio.html
@@ -1,5 +1,5 @@
 {{ if $.Param "enableBio" }}
-<section class="bio" data-dir="{{ $.Param "languagedir" | default "ltr" }}">
+<section class="bio" data-dir="{{ $.Site.Language.LanguageDirection | default "ltr" }}">
   {{ if ($.Param "enableBioImage" | default true) }}
   <hr class="hr-slash bio-hr"/>
   <div class="bio__photo-wrapper">

--- a/layouts/partials/summary/card.html
+++ b/layouts/partials/summary/card.html
@@ -2,13 +2,13 @@
   <header>
     <h5 class="title h5"><a href='{{ .Permalink }}'>{{- with .Params.pinned -}}{{ ($.Site.Params.pinIcon | safeHTML) | default "📌" }}&nbsp;{{- end -}}{{ .Title }}</a> </h5>
     <h6 class="subtitle caption">
-      <time title="{{ i18n "tooltip-written" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}">{{ ($.Site.Params.writtenTimeIcon | safeHTML) | default "📅" }}{{ .Date.Format (i18n "summary-dateformat") }} </time> 
+      <time title="{{ i18n "tooltip-written" }}" dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}">{{ ($.Site.Params.writtenTimeIcon | safeHTML) | default "📅" }}{{ .Date.Format (i18n "summary-dateformat") }} </time>
       {{ if ne (.Date.Format (i18n "summary-dateformat")) (.Lastmod.Format (i18n "summary-dateformat")) }}
-        <time title="{{ i18n "tooltip-modified" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}"> &middot; {{ ($.Site.Params.modifiedTimeIcon | safeHTML) | default "📝" }} {{ .Lastmod.Format (i18n "summary-dateformat") }} </time> 
+        <time title="{{ i18n "tooltip-modified" }}" dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}"> &middot; {{ ($.Site.Params.modifiedTimeIcon | safeHTML) | default "📝" }} {{ .Lastmod.Format (i18n "summary-dateformat") }} </time>
       {{ end }} 
-      <span title="{{ i18n "tooltip-reading-time" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}"> &middot; {{ ($.Site.Params.readingTimeIcon | safeHTML) | default "☕" }} {{ .ReadingTime }} {{ i18n "reading-time" }}</span>
+      <span title="{{ i18n "tooltip-reading-time" }}" dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}"> &middot; {{ ($.Site.Params.readingTimeIcon | safeHTML) | default "☕" }} {{ .ReadingTime }} {{ i18n "reading-time" }}</span>
       {{ with $.Param "author" }}
-      &middot; <span title="{{ i18n "single-writtenBy" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}">{{ if $.Param "AuthorEmoji" }}{{ $.Param "AuthorEmoji" }}{{ else }}{{ ($.Site.Params.authorIcon | safeHTML) | default "✍️" }}{{ end }}&nbsp;{{ . }}</span>
+      &middot; <span title="{{ i18n "single-writtenBy" }}" dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}">{{ if $.Param "AuthorEmoji" }}{{ $.Param "AuthorEmoji" }}{{ else }}{{ ($.Site.Params.authorIcon | safeHTML) | default "✍️" }}{{ end }}&nbsp;{{ . }}</span>
       {{ end }}
     </h6>
   </header>

--- a/layouts/partials/summary/classic.html
+++ b/layouts/partials/summary/classic.html
@@ -19,13 +19,13 @@
       <header>
         <h5 class="title h5"><a href='{{ .Permalink }}'>{{- with .Params.pinned -}}{{ ($.Site.Params.pinIcon | safeHTML) | default "📌" }}&nbsp;{{- end -}}{{ .Title }}</a> </h5>
         <h6 class="subtitle caption">
-          <time title="{{ i18n "tooltip-written" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}">{{ ($.Site.Params.writtenTimeIcon | safeHTML) | default "📅" }}&nbsp;{{ .Date.Format (i18n "summary-dateformat") }} </time>
+          <time title="{{ i18n "tooltip-written" }}" dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}">{{ ($.Site.Params.writtenTimeIcon | safeHTML) | default "📅" }}&nbsp;{{ .Date.Format (i18n "summary-dateformat") }} </time>
           {{ if ne (.Date.Format (i18n "summary-dateformat")) (.Lastmod.Format (i18n "summary-dateformat")) }}
-          <time title="{{ i18n "tooltip-modified" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}"> &middot; {{ ($.Site.Params.modifiedTimeIcon | safeHTML) | default "📝" }}&nbsp;{{ .Lastmod.Format (i18n "summary-dateformat") }} </time>
+          <time title="{{ i18n "tooltip-modified" }}" dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}"> &middot; {{ ($.Site.Params.modifiedTimeIcon | safeHTML) | default "📝" }}&nbsp;{{ .Lastmod.Format (i18n "summary-dateformat") }} </time>
           {{ end }}
-          <span title="{{ i18n "tooltip-reading-time" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}"> &middot; {{ ($.Site.Params.readingTimeIcon | safeHTML) | default "☕" }}&nbsp;{{ .ReadingTime }}&nbsp;{{ i18n "reading-time" }} </span>
+          <span title="{{ i18n "tooltip-reading-time" }}" dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}"> &middot; {{ ($.Site.Params.readingTimeIcon | safeHTML) | default "☕" }}&nbsp;{{ .ReadingTime }}&nbsp;{{ i18n "reading-time" }} </span>
           {{ with $.Param "author" }}
-          &middot; <span title="{{ i18n "single-writtenBy" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}">{{ if $.Param "authorEmoji" }}{{ $.Param "authorEmoji" }}{{ else }}{{ ($.Site.Params.authorIcon | safeHTML) | default "✍️" }}{{ end }}&nbsp;{{ . }}</span>
+          &middot; <span title="{{ i18n "single-writtenBy" }}" dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}">{{ if $.Param "authorEmoji" }}{{ $.Param "authorEmoji" }}{{ else }}{{ ($.Site.Params.authorIcon | safeHTML) | default "✍️" }}{{ end }}&nbsp;{{ . }}</span>
           {{ end }}
         </h6>
       </header>

--- a/layouts/partials/summary/compact.html
+++ b/layouts/partials/summary/compact.html
@@ -5,13 +5,13 @@
       <header>
         <h5 class="title h6"><a href='{{ .Permalink }}'>{{- with .Params.pinned -}}{{ ($.Site.Params.pinTimeIcon | safeHTML) | default "📌" }}&nbsp;{{- end -}}{{ .Title }}</a> </h5>
         <h6 class="subtitle caption">
-          <time title="{{ i18n "tooltip-written" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}">{{ ($.Site.Params.writtenTimeIcon | safeHTML) | default "📅" }} {{ .Date.Format (i18n "summary-dateformat") }} </time> 
+          <time title="{{ i18n "tooltip-written" }}" dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}">{{ ($.Site.Params.writtenTimeIcon | safeHTML) | default "📅" }} {{ .Date.Format (i18n "summary-dateformat") }} </time>
           {{ if ne (.Date.Format (i18n "summary-dateformat")) (.Lastmod.Format (i18n "summary-dateformat")) }}
-            <time title="{{ i18n "tooltip-modified" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}"> &middot; {{ ($.Site.Params.modifiedTimeIcon | safeHTML) | default "📝" }} {{ .Lastmod.Format (i18n "summary-dateformat") }} </time> 
+            <time title="{{ i18n "tooltip-modified" }}" dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}"> &middot; {{ ($.Site.Params.modifiedTimeIcon | safeHTML) | default "📝" }} {{ .Lastmod.Format (i18n "summary-dateformat") }} </time>
           {{ end }} 
-          <span title="{{ i18n "tooltip-reading-time" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}"> &middot; {{ ($.Site.Params.readingTimeIcon | safeHTML) | default "☕" }} {{ .ReadingTime }} {{ i18n "reading-time" }}</span>
+          <span title="{{ i18n "tooltip-reading-time" }}" dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}"> &middot; {{ ($.Site.Params.readingTimeIcon | safeHTML) | default "☕" }} {{ .ReadingTime }} {{ i18n "reading-time" }}</span>
           {{ with $params.Author }}
-          &middot; <span title="{{ i18n "single-writtenBy" }}" dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}">{{ if $params.AuthorEmoji }}{{ $params.AuthorEmoji }}{{ else }}{{ ($.Site.Params.authorIcon | safeHTML) | default "✍️" }}{{ end }}&nbsp;{{ . }}</span>
+          &middot; <span title="{{ i18n "single-writtenBy" }}" dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}">{{ if $params.AuthorEmoji }}{{ $params.AuthorEmoji }}{{ else }}{{ ($.Site.Params.authorIcon | safeHTML) | default "✍️" }}{{ end }}&nbsp;{{ . }}</span>
           {{ end }}
         </h6>
       </header>

--- a/layouts/partials/taxonomy/taxonomy-categories.html
+++ b/layouts/partials/taxonomy/taxonomy-categories.html
@@ -10,7 +10,7 @@
         {{ range $index, $element := .Site.Taxonomies.categories }}
         {{ if and $index (ge (len $element) $minItemsToShowInTagCloud) }}
             <span class="tag">
-                <a href="{{ $element.Page.RelPermalink }}" class="is-categories taxo__link" data-dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}">
+                <a href="{{ $element.Page.RelPermalink }}" class="is-categories taxo__link" data-dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}">
                     <span class="taxo__text">
                         {{ $element.Page.Title }}
                     </span>

--- a/layouts/partials/taxonomy/taxonomy-series.html
+++ b/layouts/partials/taxonomy/taxonomy-series.html
@@ -10,7 +10,7 @@
         {{ range $index, $element := .Site.Taxonomies.series }}
         {{ if and $index (ge (len $element) $minItemsToShowInTagCloud) }}
             <span class="tag">
-                <a href="{{ $element.Page.RelPermalink }}" class="is-series taxo__link" data-dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}">
+                <a href="{{ $element.Page.RelPermalink }}" class="is-series taxo__link" data-dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}">
                     <span class="taxo__text">
                         {{ $element.Page.Title }}
                     </span>

--- a/layouts/partials/taxonomy/taxonomy-tags.html
+++ b/layouts/partials/taxonomy/taxonomy-tags.html
@@ -10,7 +10,7 @@
         {{ range $index, $element := .Site.Taxonomies.tags }}
         {{ if and $index (ge (len $element) $minItemsToShowInTagCloud) }}
             <span class="tag">
-                <a href="{{ $element.Page.RelPermalink }}" class="is-tags taxo__link" data-dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}">
+                <a href="{{ $element.Page.RelPermalink }}" class="is-tags taxo__link" data-dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}">
                     <span class="taxo__text">
                         {{ $element.Page.Title }}
                     </span>

--- a/layouts/presentation/single.html
+++ b/layouts/presentation/single.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.Language.Lang }}" dir="{{ $.Param "languagedir" | default "ltr" }}">
+<html lang="{{ .Site.Language.Lang }}" dir="{{ $.Site.Language.LanguageDirection | default "ltr" }}">
   
 <head>
   <meta charset="utf-8">

--- a/layouts/publication/single.html
+++ b/layouts/publication/single.html
@@ -19,7 +19,7 @@
     <div class="pub__links">
       {{ partial "publication/pub-links" . }}
     </div>
-    <article class="single__contents" data-dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}" data-ani="{{ $.Site.Params.enableUiAnimation | default "true" }}">
+    <article class="single__contents" data-dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}" data-ani="{{ $.Site.Params.enableUiAnimation | default "true" }}">
       {{ .Params.abstract }}
       {{ .Content }}
     </article>

--- a/layouts/resume/single.html
+++ b/layouts/resume/single.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <main class="main resume">
   {{ with .Params.header }}
-    <main class="resume__section" data-dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}">
+    <main class="resume__section" data-dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}">
       <aside class="resume__section--side">
         {{ with .image }}
           <div class="resume__header--image">
@@ -39,7 +39,7 @@
     </main>
   {{ end }}
   {{ range .Params.items }}
-    <main class="resume__section" data-dir="{{ if ne ($.Param "languagedir") "rtl" }}ltr{{ else }}rtl{{ end }}">
+    <main class="resume__section" data-dir="{{ if ne $.Site.Language.LanguageDirection "rtl" }}ltr{{ else }}rtl{{ end }}">
       <aside class="resume__section--side">
         <div class="resume__section--sectiontitle">{{ .title }}</div>
       </aside>

--- a/layouts/talks/list.html
+++ b/layouts/talks/list.html
@@ -22,16 +22,16 @@
       {{ $paginator := .Paginate ($pages.GroupByPublishDate ($.Param "talksGroupByDate" | default "2006")) ($.Param "talksPaginate") }}
       {{ range ($paginator).PageGroups }}
         <span class="archive__key" data-ani="{{ $.Site.Params.enableUiAnimation | default "true" }}">{{ .Key }}</span>
-        <ul class="archive__ul" data-dir="{{ $.Param "languagedir" | default "ltr" }}">
+        <ul class="archive__ul" data-dir="{{ $.Site.Language.LanguageDirection | default "ltr" }}">
           {{ range .Pages }}
-          <li class="archive__li" data-dir="{{ $.Param "languagedir" | default "ltr" }}">
-            <span class="talk__date" data-dir="{{ $.Param "languagedir" | default "ltr" }}" data-ani="{{ $.Site.Params.enableUiAnimation | default "true" }}">
+          <li class="archive__li" data-dir="{{ $.Site.Language.LanguageDirection | default "ltr" }}">
+            <span class="talk__date" data-dir="{{ $.Site.Language.LanguageDirection | default "ltr" }}" data-ani="{{ $.Site.Params.enableUiAnimation | default "true" }}">
               {{ .PublishDate.Format (i18n "talks-dateformat") }}
             </span>
             {{ if .Params.disableLink }}
-            <div class="talk__title" data-title-wrap="{{ $titleWrap | default "wrap"}}" data-dir="{{ $.Param "languagedir" | default "ltr" }}">{{ .Title }}</div>
+            <div class="talk__title" data-title-wrap="{{ $titleWrap | default "wrap"}}" data-dir="{{ $.Site.Language.LanguageDirection | default "ltr" }}">{{ .Title }}</div>
             {{ else }}
-            <a href="{{ if .Params.externalLink }}{{ .Params.externalLink }}{{ else }}{{ .Permalink }}{{ end }}" target="{{ with .Params.externalLink }}_blank{{ end }}" rel="{{ with .Params.externalLink }}noreferrer{{ end }}" class="talk__title" data-title-wrap="{{ $titleWrap | default "wrap"}}" data-dir="{{ $.Param "languagedir" | default "ltr" }}">{{ .Title }}</a>
+            <a href="{{ if .Params.externalLink }}{{ .Params.externalLink }}{{ else }}{{ .Permalink }}{{ end }}" target="{{ with .Params.externalLink }}_blank{{ end }}" rel="{{ with .Params.externalLink }}noreferrer{{ end }}" class="talk__title" data-title-wrap="{{ $titleWrap | default "wrap"}}" data-dir="{{ $.Site.Language.LanguageDirection | default "ltr" }}">{{ .Title }}</a>
             {{ end }}
             {{ with .Params.subLinks }}
               <div class="talk__icons">


### PR DESCRIPTION
The Language.LanguageDirection parameter was merged into Hugo with [Add languageDirection to language configuration](https://github.com/gohugoio/hugo/pull/7038).

This PR replaces usage of `languagedir` in *languages.toml* with `languageDirection`, and also replaces various instances of `$.Param "languagedir"` with `$.Site.Language.LanguageDirection`.