### PR TITLE
Fix issue when using a baseURL containing a subdir

### DIFF
--- a/layouts/partials/navbar/site-nav.html
+++ b/layouts/partials/navbar/site-nav.html
@@ -1,14 +1,14 @@
 <nav class="navbar scrolling" role="navigation" aria-label="main navigation" data-dir="{{ if $.Param "navbardir" }}{{ $.Param "navbardir" }}{{ else }}{{ $.Param "languagedir" | default "ltr" }}{{ end }}">
   <div class="navbar__brand">
     {{ if $.Param "logo" | default true }}
-    <a href="{{ "/" | relLangURL }}" title="{{ i18n "tooltip-home" }}" rel="home" class="{{ if eq ($.Param "logoType") "long" }}navbar__long-link{{ else }}navbar__logo-link{{ end }}">
-      <img src="{{ "/logo.png" | relURL }}" alt="Home" class="navbar__logo">
+    <a href="{{ "" | relLangURL }}" title="{{ i18n "tooltip-home" }}" rel="home" class="{{ if eq ($.Param "logoType") "long" }}navbar__long-link{{ else }}navbar__logo-link{{ end }}">
+      <img src="{{ "logo.png" | relURL }}" alt="Home" class="navbar__logo">
     </a>
     {{ else }}
     &nbsp;&nbsp;
     {{ end }}
     {{ if ne .Site.Params.logoType "long" }}
-      <a href="{{ "/" | relLangURL }}" title="{{ i18n "tooltip-home" }}" rel="home" class="navbar__title-link">
+      <a href="{{ "" | relLangURL }}" title="{{ i18n "tooltip-home" }}" rel="home" class="navbar__title-link">
         <h6 class="navbar__title">{{ .Site.Params.logoText }}</h6>
       </a>
     {{ end }}

--- a/layouts/partials/script/pub-list-script.html
+++ b/layouts/partials/script/pub-list-script.html
@@ -10,7 +10,7 @@
   var enableSearchHighlight = JSON.parse({{ $enableSearchHighlight | jsonify }});
   {{ $isFirstSection := eq .Permalink .FirstSection.Permalink }}
   var isFirstSection = JSON.parse({{ $isFirstSection | jsonify }});
-  {{ $tagsBaseURL := ("/tags/" | relLangURL) }}
+  {{ $tagsBaseURL := ("tags/" | relLangURL) }}
   var tagsBaseURL = JSON.parse({{ $tagsBaseURL | jsonify }});
   
   document.addEventListener('DOMContentLoaded', function () {

--- a/layouts/partials/taxonomy/taxonomy-categories.html
+++ b/layouts/partials/taxonomy/taxonomy-categories.html
@@ -2,7 +2,7 @@
 <div class="taxo">
     <section>
         <span class="title p2">
-            <a href="{{ "/categories/" | relLangURL }}" class="taxo__title">
+            <a href="{{ "categories/" | relLangURL }}" class="taxo__title">
                 {{ i18n "categories" }}
             </a>
         </span>

--- a/layouts/partials/taxonomy/taxonomy-series.html
+++ b/layouts/partials/taxonomy/taxonomy-series.html
@@ -2,7 +2,7 @@
 <div class="taxo">
     <section>
         <span class="title p2">
-            <a href="{{ "/series/" | relLangURL }}" class="taxo__title">
+            <a href="{{ "series/" | relLangURL }}" class="taxo__title">
                 {{ i18n "series" }}
             </a>
         </span>

--- a/layouts/partials/taxonomy/taxonomy-tags.html
+++ b/layouts/partials/taxonomy/taxonomy-tags.html
@@ -2,7 +2,7 @@
 <div class="taxo">
     <section>
         <span class="title p2">
-            <a href="{{ "/tags/" | relLangURL }}" class="taxo__title">
+            <a href="{{ "tags/" | relLangURL }}" class="taxo__title">
                 {{ i18n "tags"}}
             </a>
         </span>


### PR DESCRIPTION
`| relURL` behaves differently when the string passed to it begins with a slash. 

https://gohugo.io/functions/relurl/#input-begins-with-a-slash